### PR TITLE
feat: add planner optimizer and mesh validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,39 @@ pytest -q
 
 This runs the full test suite using the pandas-based stub backend. No Bodo installation is required.
 
+### Running With Real Bodo
+
+If you have a licensed Bodo installation and want to exercise the real backend, set up the
+environment before running tests or benchmarks:
+
+```bash
+export DATAJAX_USE_BODO_STUB=0
+export DATAJAX_ALLOW_BODO_IMPORT=1
+export DATAJAX_EXECUTOR=bodo
+# Optional: enable native LazyPlan lowering instead of pandas replay
+export DATAJAX_NATIVE_BODO=1
+# Recommended when running under mpiexec
+export BODO_SPAWN_MODE=0
+```
+
+Recommended validation commands:
+
+```bash
+pytest tests/api/test_djit_pipeline.py -k bodo -vv
+pytest tests/runtime/test_bodo_plan.py -vv
+pytest tests/runtime/test_mesh_plan.py -vv
+```
+
+To benchmark the native execution path you will typically need to launch Bodo under MPI. For
+example, on a workstation with two ranks available:
+
+```bash
+mpiexec -n 2 python benchmarks/feature_pipeline.py --mode native --spmd
+```
+
+Unset `DATAJAX_NATIVE_BODO` or switch `--mode replay` if you prefer the pandas replay path compiled
+through `bodo.jit` without native LazyPlan lowering.
+
 ## Example Usage
 
 Here is a simple example of how to use `djit` to define a sharded, just-in-time compiled feature engineering pipeline.

--- a/datajax/__init__.py
+++ b/datajax/__init__.py
@@ -1,6 +1,16 @@
 """Top-level DataJAX package exports."""
 
-from datajax.api import DjitFunction, PartitionedFunction, Resource, ShardSpec, djit, pjit, scan, shard, vmap
+from datajax.api import (
+    DjitFunction,
+    PartitionedFunction,
+    Resource,
+    ShardSpec,
+    djit,
+    pjit,
+    scan,
+    shard,
+    vmap,
+)
 from datajax.frame import Frame
 
 __all__ = [

--- a/datajax/api/sharding.py
+++ b/datajax/api/sharding.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
 
 
 @dataclass(frozen=True)
 class Resource:
-    mesh_axes: Tuple[str, ...]
+    mesh_axes: tuple[str, ...]
     world_size: int
 
 

--- a/datajax/io/parquet.py
+++ b/datajax/io/parquet.py
@@ -2,15 +2,24 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Iterable, Optional
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
 from datajax.frame.frame import Frame
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+else:
+    Iterable = Path = Any
 
-def read_parquet(path: str | Path | Iterable[str], *, columns: Optional[list[str]] = None) -> Frame:
+
+def read_parquet(
+    path: str | Path | Iterable[str],
+    *,
+    columns: list[str] | None = None,
+) -> Frame:
     """Load Parquet data into a Frame using pandas as the execution backend."""
 
     df = pd.read_parquet(path, columns=columns)

--- a/datajax/ir/graph.py
+++ b/datajax/ir/graph.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,7 @@ class LogicalExpr(Expr):
 
 @dataclass(frozen=True)
 class InputStep:
-    schema: Tuple[str, ...]
+    schema: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ class FilterStep:
 
 @dataclass(frozen=True)
 class ProjectStep:
-    columns: Tuple[str, ...]
+    columns: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -83,7 +83,7 @@ class JoinStep:
     left_on: str
     right_on: str
     how: str
-    right_columns: Tuple[str, ...]
+    right_columns: tuple[str, ...]
     right_data: Any
 
 

--- a/datajax/planner/__init__.py
+++ b/datajax/planner/__init__.py
@@ -1,6 +1,6 @@
 """Planner utilities."""
 
-from datajax.planner.plan import ExecutionPlan, Stage, build_plan
 from datajax.planner.execute import execute_plan
+from datajax.planner.plan import ExecutionPlan, Stage, build_plan
 
 __all__ = ["ExecutionPlan", "Stage", "build_plan", "execute_plan"]

--- a/datajax/planner/execute.py
+++ b/datajax/planner/execute.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
-import pandas as pd
-
-from datajax.planner.plan import ExecutionPlan, Stage
 from datajax.runtime import bodo_codegen
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from datajax.planner.plan import ExecutionPlan, Stage
+else:
+    import types as _types
+
+    pd = _types.SimpleNamespace(DataFrame=object)
+    ExecutionPlan = Stage = Any
 
 
 def _run_transform_stage(frame: pd.DataFrame, stage: Stage) -> pd.DataFrame:
@@ -37,7 +44,12 @@ def _run_aggregate_stage(frame: pd.DataFrame, stage: Stage) -> pd.DataFrame:
     return expr_fn(frame)
 
 
-def execute_plan(plan: ExecutionPlan, *, frame: pd.DataFrame, backend_mode: str) -> pd.DataFrame:
+def execute_plan(
+    plan: ExecutionPlan,
+    *,
+    frame: pd.DataFrame,
+    backend_mode: str,
+) -> pd.DataFrame:
     current = frame
     for stage in plan.stages:
         if stage.kind == "transform":

--- a/datajax/planner/optimizer.py
+++ b/datajax/planner/optimizer.py
@@ -1,0 +1,184 @@
+"""Trace optimization utilities for the planner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from datajax.ir.graph import (
+    BinaryExpr,
+    ColumnRef,
+    ComparisonExpr,
+    Expr,
+    FilterStep,
+    LogicalExpr,
+    MapStep,
+    ProjectStep,
+    RenameExpr,
+    RepartitionStep,
+)
+from datajax.runtime.mesh import resolve_mesh_axis
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+else:
+    from collections import abc as _abc
+
+    Sequence = _abc.Sequence
+
+def _expr_columns(expr: Expr) -> set[str]:
+    """Return the set of column names referenced by an expression."""
+
+    if isinstance(expr, ColumnRef):
+        return {expr.name}
+    if isinstance(expr, RenameExpr):
+        return _expr_columns(expr.expr)
+    if isinstance(expr, BinaryExpr):
+        return _expr_columns(expr.left) | _expr_columns(expr.right)
+    if isinstance(expr, ComparisonExpr):
+        return _expr_columns(expr.left) | _expr_columns(expr.right)
+    if isinstance(expr, LogicalExpr):
+        return _expr_columns(expr.left) | _expr_columns(expr.right)
+    return set()
+
+
+def _dedup_consecutive_projects(trace: Sequence[object]) -> tuple[list[object], bool]:
+    optimized: list[object] = []
+    changed = False
+    for step in trace:
+        if (
+            isinstance(step, ProjectStep)
+            and optimized
+            and isinstance(optimized[-1], ProjectStep)
+        ):
+            optimized[-1] = step
+            changed = True
+        else:
+            optimized.append(step)
+    return optimized, changed
+
+
+def _fuse_consecutive_filters(trace: Sequence[object]) -> tuple[list[object], bool]:
+    optimized: list[object] = []
+    changed = False
+    for step in trace:
+        if (
+            isinstance(step, FilterStep)
+            and optimized
+            and isinstance(optimized[-1], FilterStep)
+        ):
+            previous = optimized[-1]
+            merged_predicate = LogicalExpr("and", previous.predicate, step.predicate)
+            optimized[-1] = FilterStep(predicate=merged_predicate)
+            changed = True
+        else:
+            optimized.append(step)
+    return optimized, changed
+
+
+def _dedup_repartitions(trace: Sequence[object]) -> tuple[list[object], bool]:
+    optimized: list[object] = []
+    changed = False
+    for step in trace:
+        if (
+            isinstance(step, RepartitionStep)
+            and optimized
+            and isinstance(optimized[-1], RepartitionStep)
+            and optimized[-1].spec == step.spec
+        ):
+            optimized[-1] = step
+            changed = True
+        else:
+            optimized.append(step)
+    return optimized, changed
+
+
+def _pushdown_filters(trace: Sequence[object]) -> tuple[list[object], bool]:
+    optimized = list(trace)
+    changed = False
+    for idx, step in enumerate(list(optimized)):
+        if not isinstance(step, FilterStep):
+            continue
+        referenced = _expr_columns(step.predicate)
+        cursor = idx - 1
+        while cursor >= 0:
+            prev = optimized[cursor]
+            if isinstance(prev, MapStep):
+                if prev.output in referenced:
+                    break
+                optimized[cursor], optimized[cursor + 1] = (
+                    optimized[cursor + 1],
+                    optimized[cursor],
+                )
+                changed = True
+                cursor -= 1
+                continue
+            if isinstance(prev, FilterStep):
+                optimized[cursor], optimized[cursor + 1] = (
+                    optimized[cursor + 1],
+                    optimized[cursor],
+                )
+                changed = True
+                cursor -= 1
+                continue
+            break
+    return optimized, changed
+
+
+def optimize_trace(trace: Sequence[object]) -> list[object]:
+    """Apply simple optimizer passes (fusion, pushdown) to a trace."""
+
+    optimized = list(trace)
+    changed = True
+    while changed:
+        changed = False
+        optimized, did_change = _dedup_consecutive_projects(optimized)
+        changed = changed or did_change
+        optimized, did_change = _fuse_consecutive_filters(optimized)
+        changed = changed or did_change
+        optimized, did_change = _dedup_repartitions(optimized)
+        changed = changed or did_change
+        optimized, did_change = _pushdown_filters(optimized)
+        changed = changed or did_change
+    return optimized
+
+
+def validate_mesh_axes(trace: Sequence[object], resources: Any) -> None:
+    """Ensure repartition specs reference valid mesh axes for the given resources."""
+
+    if resources is None:
+        for step in trace:
+            if isinstance(step, RepartitionStep):
+                spec = step.spec
+                axis = getattr(spec, "axis", None)
+                if axis is not None:
+                    raise ValueError(
+                        "ShardSpec.axis requires Resource mesh information "
+                        "when provided"
+                    )
+        return
+
+    axes = tuple(getattr(resources, "mesh_axes", ()) or ())
+
+    for step in trace:
+        if not isinstance(step, RepartitionStep):
+            continue
+        spec = step.spec
+        axis = getattr(spec, "axis", None)
+        if axis is None:
+            continue
+        if isinstance(axis, str):
+            if axis not in axes:
+                raise ValueError(
+                    f"Unknown mesh axis {axis!r}; available axes: {axes!r}"
+                )
+        elif isinstance(axis, int):
+            if not axes:
+                raise ValueError("ShardSpec.axis index requires a non-empty mesh_axes")
+            if axis < 0 or axis >= len(axes):
+                raise ValueError(
+                    f"Axis index {axis} is out of range for mesh axes {axes!r}"
+                )
+        resolve_mesh_axis(axis, resources, 0)
+
+
+__all__ = ["optimize_trace", "validate_mesh_axes"]

--- a/datajax/runtime/__init__.py
+++ b/datajax/runtime/__init__.py
@@ -1,5 +1,10 @@
 """Runtime helpers for DataJAX."""
 
+from datajax.runtime.bodo_pipeline import (
+    CompiledPlan,
+    CompiledStage,
+    compile_plan_with_backend,
+)
 from datajax.runtime.executor import (
     BodoBackend,
     ExecutionBackend,
@@ -8,7 +13,6 @@ from datajax.runtime.executor import (
     get_active_backend,
     reset_backend,
 )
-from datajax.runtime.bodo_pipeline import CompiledPlan, CompiledStage, compile_plan_with_backend
 
 __all__ = [
     "BodoBackend",

--- a/datajax/runtime/bodo_native.py
+++ b/datajax/runtime/bodo_native.py
@@ -12,12 +12,16 @@ helpers defined in `bodo/pandas/plan.py` and `bodo/pandas/frame.py`.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import TYPE_CHECKING
 
-import pandas as pd
-
-from datajax.ir import graph
 from datajax.planner.plan import ExecutionPlan, Stage
+
+if TYPE_CHECKING:
+    import pandas as pd
+else:
+    import types as _types
+
+    pd = _types.SimpleNamespace(DataFrame=object)
 
 
 @dataclass
@@ -28,7 +32,7 @@ class NativeStage:
     description: str
 
 
-def lower_plan_to_bodo(plan: ExecutionPlan, frame: pd.DataFrame) -> List[NativeStage]:
+def lower_plan_to_bodo(plan: ExecutionPlan, frame: pd.DataFrame) -> list[NativeStage]:
     """Return a high-level lowering plan for Bodo.
 
     Parameters
@@ -59,14 +63,15 @@ def lower_plan_to_bodo(plan: ExecutionPlan, frame: pd.DataFrame) -> List[NativeS
       can be carried out on an environment where Bodo is fully available.
     """
 
-    native: List[NativeStage] = []
+    native: list[NativeStage] = []
 
     native.append(
         NativeStage(
             stage=plan.stages[0] if plan.stages else Stage("input", (), (), (), None),
             description=(
-                "Create the base LazyPlan using LogicalGetPandasReadSeq/Parallel. "
-                "Use frame.head(0) to build the schema (see bodo.pandas.base._empty_like)."
+                "Create the base LazyPlan using "
+                "LogicalGetPandasReadSeq/Parallel. Use frame.head(0) to build "
+                "the schema (see bodo.pandas.base._empty_like)."
             ),
         )
     )
@@ -77,9 +82,9 @@ def lower_plan_to_bodo(plan: ExecutionPlan, frame: pd.DataFrame) -> List[NativeS
                 NativeStage(
                     stage=stage,
                     description=(
-                        "Translate Map/Filter/Project steps into LogicalProjection/"
-                        "LogicalFilter with ColRefExpression, ArithOpExpression, and "
-                        "ComparisonOpExpression."
+                        "Translate Map/Filter/Project steps into "
+                        "LogicalProjection/LogicalFilter with ColRefExpression, "
+                        "ArithOpExpression, and ComparisonOpExpression."
                     ),
                 )
             )
@@ -109,7 +114,7 @@ def lower_plan_to_bodo(plan: ExecutionPlan, frame: pd.DataFrame) -> List[NativeS
                     stage=stage,
                     description=(
                         "Insert a repartition node (check Bodo for the appropriate "
-                        "Logical* class).  Update sharding state accordingly."
+                        "Logical* class). Update sharding state accordingly."
                     ),
                 )
             )
@@ -120,7 +125,7 @@ def lower_plan_to_bodo(plan: ExecutionPlan, frame: pd.DataFrame) -> List[NativeS
                 NativeStage(
                     stage=stage,
                     description=(
-                        "TODO: implement lowering for stage kind %s" % stage.kind
+                        f"TODO: implement lowering for stage kind {stage.kind}"
                     ),
                 )
             )

--- a/datajax/runtime/bodo_pipeline.py
+++ b/datajax/runtime/bodo_pipeline.py
@@ -3,16 +3,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, List, Sequence, Tuple
-
-import pandas as pd
+from typing import TYPE_CHECKING, Any
 
 from datajax.runtime import bodo_codegen
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    import pandas as pd
+
+    from datajax.planner.plan import ExecutionPlan, Stage
+else:
+    import types as _types
+    from collections import abc as _abc
+
+    Callable = _abc.Callable
+    Sequence = _abc.Sequence
+    pd = _types.SimpleNamespace(DataFrame=object)
+    ExecutionPlan = Stage = Any
 
 
 @dataclass(frozen=True)
 class CompiledStage:
-    stage: "Stage"
+    stage: Stage
     fn: Callable[[pd.DataFrame], pd.DataFrame]
     source: str
 
@@ -20,9 +33,9 @@ class CompiledStage:
 @dataclass(frozen=True)
 class CompiledPlan:
     stages: Sequence[CompiledStage]
-    final_schema: Tuple[str, ...]
+    final_schema: tuple[str, ...]
     sharding: object | None
-    trace_signature: Tuple[object, ...]
+    trace_signature: tuple[object, ...]
 
     def run(self, frame: pd.DataFrame) -> pd.DataFrame:
         current = frame
@@ -31,11 +44,11 @@ class CompiledPlan:
         return current
 
 
-def compile_plan_with_backend(plan: "ExecutionPlan", backend) -> CompiledPlan:
-    from datajax.planner.plan import ExecutionPlan, Stage
+def compile_plan_with_backend(plan: ExecutionPlan, backend) -> CompiledPlan:
+    from datajax.planner.plan import Stage
 
     namespace_cache: dict[str, object] | None = None
-    compiled_stages: List[CompiledStage] = []
+    compiled_stages: list[CompiledStage] = []
 
     for stage in plan.stages:
         if stage.kind == "input":
@@ -45,17 +58,23 @@ def compile_plan_with_backend(plan: "ExecutionPlan", backend) -> CompiledPlan:
                 stage.steps, reuse_namespace=namespace_cache
             )
             compiled_fn = backend.compile_callable(fn)
-            compiled_stages.append(CompiledStage(stage=stage, fn=compiled_fn, source=source))
+            compiled_stages.append(
+                CompiledStage(stage=stage, fn=compiled_fn, source=source)
+            )
         elif stage.kind == "repartition":
             def identity(frame: pd.DataFrame) -> pd.DataFrame:
                 return frame
 
-            compiled_stages.append(CompiledStage(stage=stage, fn=identity, source="repartition"))
+            compiled_stages.append(
+                CompiledStage(stage=stage, fn=identity, source="repartition")
+            )
         else:
             raise NotImplementedError(f"Unsupported stage kind {stage.kind}")
 
     if not compiled_stages:
-        fn, source, namespace_cache = bodo_codegen.generate_bodo_callable(plan.trace, reuse_namespace=namespace_cache)
+        fn, source, namespace_cache = bodo_codegen.generate_bodo_callable(
+            plan.trace, reuse_namespace=namespace_cache
+        )
         compiled_fn = backend.compile_callable(fn)
         input_schema = plan.stages[0].input_schema if plan.stages else tuple()
         fallback_stage = Stage(
@@ -65,7 +84,9 @@ def compile_plan_with_backend(plan: "ExecutionPlan", backend) -> CompiledPlan:
             output_schema=plan.final_schema,
             target_sharding=plan.final_sharding,
         )
-        compiled_stages.append(CompiledStage(stage=fallback_stage, fn=compiled_fn, source=source))
+        compiled_stages.append(
+            CompiledStage(stage=fallback_stage, fn=compiled_fn, source=source)
+        )
 
     return CompiledPlan(
         stages=tuple(compiled_stages),

--- a/datajax/runtime/bodo_stub.py
+++ b/datajax/runtime/bodo_stub.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any, Callable, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+else:
+    from collections import abc as _abc
+
+    Callable = _abc.Callable
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -18,7 +25,12 @@ def jit(fn: F, *, parallel: bool | None = None, **_: Any) -> F:
     ...
 
 
-def jit(fn: F | None = None, *, parallel: bool | None = None, **_: Any) -> F | Callable[[F], F]:
+def jit(
+    fn: F | None = None,
+    *,
+    parallel: bool | None = None,
+    **_: Any,
+) -> F | Callable[[F], F]:
     """Return a decorator that behaves like bodo.jit but simply returns the input."""
 
     def decorator(inner: F) -> F:

--- a/datajax/runtime/mesh.py
+++ b/datajax/runtime/mesh.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Sequence, Tuple
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+else:
+    from collections import abc as _abc
+
+    Sequence = _abc.Sequence
 
 
 def mesh_shape_from_resource(resources, world_size: int) -> tuple[int, ...]:
@@ -42,7 +48,9 @@ def resolve_mesh_axis(axis: str | int | None, resources, default: int = 0) -> in
         if not axes:
             return max(0, axis)
         if axis < 0 or axis >= len(axes):
-            raise ValueError(f"Axis index {axis} is out of range for mesh axes {axes!r}")
+            raise ValueError(
+                f"Axis index {axis} is out of range for mesh axes {axes!r}"
+            )
         return axis
     if isinstance(axis, str):
         if axis not in axes:
@@ -83,7 +91,12 @@ def compute_destinations_for_mesh(
     return dests.astype(np.int32)
 
 
-def compute_destinations_by_key(df, key: str, mesh_shape: Sequence[int], axis_index: int) -> np.ndarray:
+def compute_destinations_by_key(
+    df,
+    key: str,
+    mesh_shape: Sequence[int],
+    axis_index: int,
+) -> np.ndarray:
     import pandas as pd
 
     hashed = pd.util.hash_pandas_object(df[key], index=False).to_numpy(dtype=np.uint64)
@@ -103,4 +116,3 @@ def rebalance_by_key(df, key: str, mesh_shape: Sequence[int], axis_index: int = 
 
     dests = compute_destinations_by_key(df, key, mesh_shape, axis_index)
     return distributed_api.rebalance(df, dests=dests)
-

--- a/datajax/runtime/plan_diagnostics.py
+++ b/datajax/runtime/plan_diagnostics.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+else:
+    from collections import abc as _abc
+
+    Iterable = _abc.Iterable
 
 
 @dataclass
@@ -18,4 +25,3 @@ class PlanDiagnostics:
 
     def describe(self) -> list[str]:
         return list(self.notes)
-

--- a/tests/api/test_djit_pipeline.py
+++ b/tests/api/test_djit_pipeline.py
@@ -7,7 +7,6 @@ from types import ModuleType
 
 import pandas as pd
 import pytest
-
 from datajax import Frame, Resource, djit, pjit, scan, shard, vmap
 from datajax.ir.graph import AggregateStep, InputStep, MapStep
 from datajax.runtime import executor as runtime_executor
@@ -76,7 +75,9 @@ def test_pjit_wrapper_preserves_lower(sample_frame: pd.DataFrame) -> None:
         assert any("AggregateStep" in desc for desc in plan.describe())
         assert plan.mode in {"stub", "real", "pandas"}
         assert plan.final_schema == ("user_id", "revenue")
-        transform_stage = next(stage for stage in plan.stages if stage.kind == "transform")
+        transform_stage = next(
+            stage for stage in plan.stages if stage.kind == "transform"
+        )
         assert "MapStep" in transform_stage.describe()
 
 
@@ -107,7 +108,9 @@ def test_scan_accumulates_sequence() -> None:
     assert outputs == [1, 3, 6]
 
 
-def test_executor_prefers_bodo_but_falls_back_to_pandas(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_executor_prefers_bodo_but_falls_back_to_pandas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     runtime_executor.reset_backend()
     monkeypatch.delenv("DATAJAX_EXECUTOR", raising=False)
     monkeypatch.delenv("DATAJAX_USE_BODO_STUB", raising=False)
@@ -129,7 +132,9 @@ def test_executor_env_requires_bodo(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime_executor.reset_backend()
 
 
-def test_executor_auto_falls_back_when_stub_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_executor_auto_falls_back_when_stub_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     runtime_executor.reset_backend()
     monkeypatch.setenv("DATAJAX_USE_BODO_STUB", "0")
     monkeypatch.setenv("DATAJAX_ALLOW_BODO_IMPORT", "0")
@@ -163,7 +168,9 @@ def test_bodo_stub_module_available(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime_executor.reset_backend()
 
 
-def test_executor_uses_real_bodo_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_executor_uses_real_bodo_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     runtime_executor.reset_backend()
 
     module = ModuleType("bodo")
@@ -208,7 +215,7 @@ def test_executor_uses_real_bodo_when_available(monkeypatch: pytest.MonkeyPatch)
     backend_name = runtime_executor.active_backend_name()
     assert backend_name == "bodo"
     backend_impl = runtime_executor.get_active_backend()
-    assert getattr(backend_impl, "mode") == "real"
+    assert backend_impl.mode == "real"
 
     @djit
     def identity(df: Frame) -> Frame:
@@ -294,7 +301,10 @@ def test_pjit_shard_axis_validation_index_invalid(sample_frame: pd.DataFrame) ->
     with pytest.raises(ValueError):
         compiled(sample_frame)
 
-def test_djit_bodo_native_execution(sample_frame: pd.DataFrame, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_djit_bodo_native_execution(
+    sample_frame: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tests that the Bodo-native execution path is used when the backend is Bodo."""
     if os.environ.get("DATAJAX_NATIVE_BODO", "0") != "1":
         pytest.skip("Native Bodo lowering is disabled")

--- a/tests/frame/test_frame_ops.py
+++ b/tests/frame/test_frame_ops.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import pandas as pd
-
-from datajax.frame.frame import Frame
 from datajax.api.sharding import shard
+from datajax.frame.frame import Frame
 from datajax.ir.graph import (
     AggregateStep,
     FilterStep,
@@ -28,7 +27,9 @@ def test_frame_filter_and_map(sample_frame: pd.DataFrame) -> None:
     output = aggregated.to_pandas().sort_values("user_id").reset_index(drop=True)
     pandas_filtered = sample_frame[sample_frame["qty"] > 2]
     expected = (pandas_filtered["unit_price"] * pandas_filtered["qty"]).rename("total")
-    expected = expected.groupby(pandas_filtered["user_id"]).sum().reset_index(name="total")
+    expected = (
+        expected.groupby(pandas_filtered["user_id"]).sum().reset_index(name="total")
+    )
     expected = expected.sort_values("user_id").reset_index(drop=True)
 
     pd.testing.assert_frame_equal(output, expected)

--- a/tests/planner/test_optimizer.py
+++ b/tests/planner/test_optimizer.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+from datajax.api.sharding import Resource, shard
+from datajax.ir.graph import (
+    BinaryExpr,
+    ColumnRef,
+    ComparisonExpr,
+    FilterStep,
+    InputStep,
+    Literal,
+    LogicalExpr,
+    MapStep,
+    ProjectStep,
+    RepartitionStep,
+)
+from datajax.planner.optimizer import optimize_trace
+from datajax.planner.plan import build_plan
+
+
+def _dummy_trace(*steps):
+    return [InputStep(("user_id", "qty", "unit_price")), *steps]
+
+
+def test_filter_pushdown_moves_before_independent_map():
+    trace = _dummy_trace(
+        MapStep(
+            output="revenue",
+            expr=BinaryExpr("mul", ColumnRef("unit_price"), ColumnRef("qty")),
+        ),
+        FilterStep(
+            predicate=ComparisonExpr("gt", ColumnRef("qty"), Literal(2)),
+        ),
+    )
+
+    optimized = optimize_trace(trace)
+    kinds = [type(step) for step in optimized]
+    assert kinds == [InputStep, FilterStep, MapStep]
+
+
+def test_filter_is_not_pushed_past_dependent_map():
+    trace = _dummy_trace(
+        MapStep(
+            output="revenue",
+            expr=BinaryExpr("mul", ColumnRef("unit_price"), ColumnRef("qty")),
+        ),
+        FilterStep(
+            predicate=ComparisonExpr("gt", ColumnRef("revenue"), Literal(20)),
+        ),
+    )
+
+    optimized = optimize_trace(trace)
+    kinds = [type(step) for step in optimized]
+    assert kinds == [InputStep, MapStep, FilterStep]
+
+
+def test_build_plan_uses_optimized_trace_order():
+    trace = _dummy_trace(
+        MapStep(
+            output="revenue",
+            expr=BinaryExpr("mul", ColumnRef("unit_price"), ColumnRef("qty")),
+        ),
+        FilterStep(
+            predicate=ComparisonExpr("gt", ColumnRef("qty"), Literal(2)),
+        ),
+    )
+
+    plan = build_plan(trace, backend="pandas", mode="stub", resources=None)
+    transform_stage = next(stage for stage in plan.stages if stage.kind == "transform")
+    step_types = tuple(type(step) for step in transform_stage.steps)
+    assert step_types == (FilterStep, MapStep)
+
+
+def test_consecutive_projects_fuse_to_last_projection():
+    trace = _dummy_trace(
+        ProjectStep(columns=("user_id", "qty")),
+        ProjectStep(columns=("user_id",)),
+    )
+
+    optimized = optimize_trace(trace)
+    projects = [step for step in optimized if isinstance(step, ProjectStep)]
+    assert len(projects) == 1
+    assert projects[0].columns == ("user_id",)
+
+
+def test_consecutive_filters_fuse_with_logical_and():
+    trace = _dummy_trace(
+        FilterStep(predicate=ComparisonExpr("gt", ColumnRef("qty"), Literal(1))),
+        FilterStep(predicate=ComparisonExpr("lt", ColumnRef("qty"), Literal(5))),
+    )
+
+    optimized = optimize_trace(trace)
+    filters = [step for step in optimized if isinstance(step, FilterStep)]
+    assert len(filters) == 1
+    predicate = filters[0].predicate
+    assert isinstance(predicate, LogicalExpr)
+    assert predicate.op == "and"
+
+
+def test_consecutive_repartitions_with_same_spec_deduplicate():
+    spec = shard.by_key("user_id")
+    trace = _dummy_trace(RepartitionStep(spec=spec), RepartitionStep(spec=spec))
+
+    optimized = optimize_trace(trace)
+    repartitions = [step for step in optimized if isinstance(step, RepartitionStep)]
+    assert len(repartitions) == 1
+
+
+def test_build_plan_validates_mesh_axis_name():
+    spec = shard.by_key("user_id", axis="cols")
+    trace = _dummy_trace(RepartitionStep(spec=spec))
+    resources = Resource(mesh_axes=("rows",), world_size=4)
+
+    with pytest.raises(ValueError):
+        build_plan(trace, backend="pandas", mode="stub", resources=resources)
+
+
+def test_build_plan_requires_resources_when_axis_set():
+    spec = shard.by_key("user_id", axis="rows")
+    trace = _dummy_trace(RepartitionStep(spec=spec))
+
+    with pytest.raises(ValueError):
+        build_plan(trace, backend="pandas", mode="stub", resources=None)
+
+
+def test_build_plan_validates_axis_index_range():
+    spec = shard.by_key("user_id", axis=1)
+    trace = _dummy_trace(RepartitionStep(spec=spec))
+    resources = Resource(mesh_axes=("rows",), world_size=2)
+
+    with pytest.raises(ValueError):
+        build_plan(trace, backend="pandas", mode="stub", resources=resources)

--- a/tests/runtime/test_bodo_plan.py
+++ b/tests/runtime/test_bodo_plan.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
-
 from datajax.frame.frame import Frame
 from datajax.runtime.bodo_plan import DataJAXPlan
 
@@ -57,7 +56,8 @@ def test_native_plan_count_dtype(sample_frame: pd.DataFrame) -> None:
     aggregates = [
         node
         for node in _collect_lazy_nodes(plan)
-        if isinstance(node, LogicalAggregate) or getattr(node, "plan_class", None) == "LogicalAggregate"
+        if isinstance(node, LogicalAggregate)
+        or getattr(node, "plan_class", None) == "LogicalAggregate"
     ]
     assert aggregates, "Expected an aggregate node in the native plan"
 


### PR DESCRIPTION
## Summary
- add trace optimizer with filter pushdown, projection/repartition dedupe, and mesh axis validation
- wire optimizer into plan building and document Bodo execution flow
- add unit coverage for optimizer rules and mesh axis enforcement

## Testing
- ruff check datajax tests
- pytest -q