### PR TITLE
feat: plan introspection + execution hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+
+# Use bd merge for beads JSONL files
+.beads/issues.jsonl merge=beads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Run gates
+        env:
+          AGENT_MODE: baseline
+        run: |
+          make setup
+          make all

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/
 .idea/
 .vscode/
 .claude/
+.codex/
 
 # Local data / outputs
 bench.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.0
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright (make type)
+        entry: make type
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: setup bootstrap check format lint type test deps-audit all fix clean
+
+AGENT_MODE ?= baseline
+VENV ?= .venv
+PYTHON ?= $(VENV)/bin/python
+
+setup:
+	uv venv $(VENV)
+	uv pip install -e '.[dev]' --python $(PYTHON)
+
+bootstrap: setup
+
+format:
+	$(VENV)/bin/ruff format .
+
+lint:
+	$(VENV)/bin/ruff check .
+
+type:
+	$(VENV)/bin/pyright
+
+check:
+	$(VENV)/bin/ruff format --check .
+	$(VENV)/bin/ruff check .
+	$(VENV)/bin/pyright
+
+fix:
+	$(VENV)/bin/ruff check --fix .
+	$(VENV)/bin/ruff format .
+
+test:
+	$(VENV)/bin/pytest -q
+
+deps-audit:
+	@if [ "$(AGENT_MODE)" = "production" ]; then \
+		$(VENV)/bin/pip-audit --progress-spinner off . ; \
+	else \
+		$(VENV)/bin/pip-audit --progress-spinner off . || echo "pip-audit reported issues (advisory in baseline)" ; \
+	fi
+
+all:
+	$(MAKE) check
+	$(MAKE) test
+	$(MAKE) deps-audit
+
+clean:
+	rm -rf $(VENV)

--- a/benchmarks/feature_pipeline.py
+++ b/benchmarks/feature_pipeline.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+
 from datajax import Frame, djit, pjit, shard
 from datajax.api.sharding import Resource
 from datajax.planner.metrics import metrics_to_dict

--- a/datajax/cli/__init__.py
+++ b/datajax/cli/__init__.py
@@ -2,4 +2,6 @@
 
 from __future__ import annotations
 
+from datajax.cli import export_wavespec, replay_tuner
+
 __all__ = ["export_wavespec", "replay_tuner"]

--- a/datajax/io/parquet.py
+++ b/datajax/io/parquet.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pandas as pd
 
@@ -22,7 +22,7 @@ def read_parquet(
 ) -> Frame:
     """Load Parquet data into a Frame using pandas as the execution backend."""
 
-    df = pd.read_parquet(path, columns=columns)
+    df = pd.read_parquet(cast("Any", path), columns=columns)
     return Frame.from_pandas(df)
 
 

--- a/datajax/jax_bridge/tpu_adapter.py
+++ b/datajax/jax_bridge/tpu_adapter.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass, replace
-from typing import Any, Callable, Mapping, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
-
-from datajax.jax_bridge.lowering import LoweredPlan
 from datajax.runtime.mesh import mesh_shape_from_resource
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable, Mapping, MutableMapping, Sequence
+
+    from datajax.jax_bridge.lowering import LoweredPlan
+else:  # pragma: no cover
+    Callable = Mapping = MutableMapping = Sequence = LoweredPlan = Any
 
 try:  # pragma: no cover - optional dependency
     import jax.numpy as jnp
-    from jax.sharding import PartitionSpec
 except ImportError:  # pragma: no cover - surfaced at runtime
-    PartitionSpec = Any  # type: ignore[assignment]
     jnp = None  # type: ignore[assignment]
 
 
@@ -34,13 +37,13 @@ class DataJAXModelDefinition:
     out_partition: tuple[str | None, ...] | None
     metadata: Mapping[str, Any]
 
-    def with_metadata(self, **extra: Any) -> "DataJAXModelDefinition":
+    def with_metadata(self, **extra: Any) -> DataJAXModelDefinition:
         merged = dict(self.metadata)
         merged.update(extra)
         return replace(self, metadata=merged)
 
 
-def _partition_to_tuple(spec: PartitionSpec | None) -> tuple[str | None, ...] | None:
+def _partition_to_tuple(spec: Any | None) -> tuple[str | None, ...] | None:
     if spec is None:
         return None
     axes: Sequence[Any] = getattr(spec, "partition_spec", spec)  # type: ignore[attr-defined]
@@ -102,7 +105,9 @@ def register_with_tpu_inference(
 
     if register_fn is None:
         try:
-            from tpu_inference.models.common import model_loader
+            model_loader = importlib.import_module(
+                "tpu_inference.models.common.model_loader"
+            )
         except ImportError as exc:  # pragma: no cover - optional dependency
             raise TPUIntegrationError(
                 "tpu-inference is not installed; install the optional "
@@ -112,10 +117,16 @@ def register_with_tpu_inference(
         register_fn = getattr(model_loader, "register_model", None)
         if register_fn is None:
             raise TPUIntegrationError(
-                "tpu_inference.models.common.model_loader.register_model is unavailable."
+                "tpu_inference.models.common.model_loader.register_model is "
+                "unavailable."
             )
 
     return register_fn(definition.model_id, definition)
 
 
-__all__ = ["DataJAXModelDefinition", "TPUIntegrationError", "build_tpu_model_definition", "register_with_tpu_inference"]
+__all__ = [
+    "DataJAXModelDefinition",
+    "TPUIntegrationError",
+    "build_tpu_model_definition",
+    "register_with_tpu_inference",
+]

--- a/datajax/jax_bridge/tpu_adapter.py
+++ b/datajax/jax_bridge/tpu_adapter.py
@@ -16,7 +16,7 @@ else:  # pragma: no cover
     Callable = Mapping = MutableMapping = Sequence = LoweredPlan = Any
 
 try:  # pragma: no cover - optional dependency
-    import jax.numpy as jnp
+    import jax.numpy as jnp  # pyright: ignore[reportMissingImports]
 except ImportError:  # pragma: no cover - surfaced at runtime
     jnp = None  # type: ignore[assignment]
 

--- a/datajax/planner/metrics.py
+++ b/datajax/planner/metrics.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from collections.abc import Mapping, Sequence
 
     import pandas as pd
-
-    from datajax.planner.plan import ExecutionPlan
 else:  # pragma: no cover - runtime types
     import types as _types
     from collections import abc as _abc
@@ -136,7 +134,7 @@ def _collect_column_usage(trace: Sequence[object]) -> dict[str, int]:
 
 
 def estimate_plan_metrics(
-    plan: ExecutionPlan,
+    plan: Any,
     *,
     sample_df: pd.DataFrame | None = None,
 ) -> PlanMetrics:
@@ -145,7 +143,7 @@ def estimate_plan_metrics(
     Parameters
     ----------
     plan:
-        The ExecutionPlan to analyze.
+        Plan-like object to analyze.
     sample_df:
         Optional concrete input frame used for scale estimates.
     """

--- a/datajax/planner/optimizer.py
+++ b/datajax/planner/optimizer.py
@@ -25,6 +25,7 @@ else:
 
     Sequence = _abc.Sequence
 
+
 def _expr_columns(expr: Expr) -> set[str]:
     """Return the set of column names referenced by an expression."""
 

--- a/datajax/planner/replay.py
+++ b/datajax/planner/replay.py
@@ -10,7 +10,7 @@ This module lets you:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from datajax.ir.serialize import trace_from_list
 from datajax.planner.metrics import PlanMetrics, estimate_plan_metrics
@@ -90,7 +90,10 @@ def replay_and_tune(
     # Detect serialized form (sequence of dicts)
     items = list(trace_or_serialized)
     if items and isinstance(items[0], dict):
-        trace = trace_from_list(items, rhs_tables=rhs_tables)
+        trace = trace_from_list(
+            cast("list[dict[str, Any]]", items),
+            rhs_tables=rhs_tables,
+        )
     else:
         trace = items  # type: ignore[assignment]
 

--- a/datajax/runtime/bodo_pipeline.py
+++ b/datajax/runtime/bodo_pipeline.py
@@ -62,6 +62,7 @@ def compile_plan_with_backend(plan: ExecutionPlan, backend) -> CompiledPlan:
                 CompiledStage(stage=stage, fn=compiled_fn, source=source)
             )
         elif stage.kind == "repartition":
+
             def identity(frame: pd.DataFrame) -> pd.DataFrame:
                 return frame
 

--- a/datajax/runtime/bodo_plan.py
+++ b/datajax/runtime/bodo_plan.py
@@ -28,7 +28,6 @@ from datajax.runtime.mesh import (
 from datajax.runtime.plan_diagnostics import PlanDiagnostics
 
 _BODO_IMPORT_ERROR: Exception | None
-LazyPlan: type[Any]
 
 LazyPlanLike: TypeAlias = Any
 
@@ -57,7 +56,10 @@ try:  # pragma: no cover - optional dependency
 except Exception as exc:  # pragma: no cover - optional dependency
     bodo = None  # type: ignore[assignment]
     plan_optimizer = None  # type: ignore[assignment]
-    LazyPlan = object  # type: ignore[assignment]
+
+    class LazyPlan:  # pragma: no cover
+        pass
+
     _BODO_STUB = cast("Any", object)
     (
         AggregateExpression,
@@ -89,7 +91,7 @@ else:
     Sequence = _abc.Sequence
 
 
-class DataJAXPlan(LazyPlan):
+class DataJAXPlan(cast("type[Any]", LazyPlan)):
     """Translate DataJAX IR steps into Bodo LazyPlan nodes."""
 
     _ARITH_OPS = {

--- a/datajax/runtime/bodo_plan.py
+++ b/datajax/runtime/bodo_plan.py
@@ -1,30 +1,9 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
-import bodo
 import pandas as pd
-from bodo.ext import plan_optimizer
-from bodo.pandas.plan import (
-    AggregateExpression,
-    ArithOpExpression,
-    ColRefExpression,
-    ComparisonOpExpression,
-    ConjunctionOpExpression,
-    ConstantExpression,
-    LazyPlan,
-    LazyPlanDistributedArg,
-    LogicalAggregate,
-    LogicalComparisonJoin,
-    LogicalFilter,
-    LogicalGetPandasReadParallel,
-    LogicalGetPandasReadSeq,
-    LogicalProjection,
-    _get_df_python_func_plan,
-    make_col_ref_exprs,
-)
-from bodo.pandas.utils import get_n_index_arrays
 
 from datajax.ir.graph import (
     AggregateStep,
@@ -47,6 +26,60 @@ from datajax.runtime.mesh import (
     resolve_mesh_axis,
 )
 from datajax.runtime.plan_diagnostics import PlanDiagnostics
+
+_BODO_IMPORT_ERROR: Exception | None
+LazyPlan: type[Any]
+
+LazyPlanLike: TypeAlias = Any
+
+try:  # pragma: no cover - optional dependency
+    import bodo  # type: ignore[import-not-found]
+    from bodo.ext import plan_optimizer  # type: ignore[import-not-found]
+    from bodo.pandas.plan import (  # type: ignore[import-not-found]
+        AggregateExpression,
+        ArithOpExpression,
+        ColRefExpression,
+        ComparisonOpExpression,
+        ConjunctionOpExpression,
+        ConstantExpression,
+        LazyPlan,
+        LazyPlanDistributedArg,
+        LogicalAggregate,
+        LogicalComparisonJoin,
+        LogicalFilter,
+        LogicalGetPandasReadParallel,
+        LogicalGetPandasReadSeq,
+        LogicalProjection,
+        _get_df_python_func_plan,
+        make_col_ref_exprs,
+    )
+    from bodo.pandas.utils import get_n_index_arrays  # type: ignore[import-not-found]
+except Exception as exc:  # pragma: no cover - optional dependency
+    bodo = None  # type: ignore[assignment]
+    plan_optimizer = None  # type: ignore[assignment]
+    LazyPlan = object  # type: ignore[assignment]
+    _BODO_STUB = cast("Any", object)
+    (
+        AggregateExpression,
+        ArithOpExpression,
+        ColRefExpression,
+        ComparisonOpExpression,
+        ConjunctionOpExpression,
+        ConstantExpression,
+        LazyPlanDistributedArg,
+        LogicalAggregate,
+        LogicalComparisonJoin,
+        LogicalFilter,
+        LogicalGetPandasReadParallel,
+        LogicalGetPandasReadSeq,
+        LogicalProjection,
+        _get_df_python_func_plan,
+        make_col_ref_exprs,
+        get_n_index_arrays,
+    ) = (_BODO_STUB,) * 16
+    _BODO_IMPORT_ERROR = exc
+else:
+    _BODO_IMPORT_ERROR = None
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -85,13 +118,6 @@ class DataJAXPlan(LazyPlan):
         "mean": pd.Series([], dtype="float64").dtype,
     }
 
-    _JOIN_TYPES = {
-        "inner": plan_optimizer.CJoinType.INNER,
-        "left": plan_optimizer.CJoinType.LEFT,
-        "right": plan_optimizer.CJoinType.RIGHT,
-        "outer": plan_optimizer.CJoinType.OUTER,
-    }
-
     def __init__(
         self,
         trace: Sequence[object],
@@ -99,6 +125,12 @@ class DataJAXPlan(LazyPlan):
         *,
         resources: object | None = None,
     ) -> None:
+        if bodo is None or plan_optimizer is None:
+            raise RuntimeError(
+                "Native Bodo lowering requires a real Bodo installation. "
+                "Install the optional dependency group `datajax[bodo]`."
+            ) from _BODO_IMPORT_ERROR
+
         self.trace = trace
         self._input_df = input_df
         self.resources = resources
@@ -141,8 +173,9 @@ class DataJAXPlan(LazyPlan):
     def _empty_series(self, dtype, name: str | None = None) -> pd.Series:
         return pd.Series([], dtype=dtype, name=name)
 
-    def _plan_from_pandas(self, df: pd.DataFrame) -> LazyPlan:
+    def _plan_from_pandas(self, df: pd.DataFrame) -> LazyPlanLike:
         empty = df.head(0)
+        assert bodo is not None
         if bodo.dataframe_library_run_parallel:
             return LogicalGetPandasReadParallel(
                 empty,
@@ -151,7 +184,19 @@ class DataJAXPlan(LazyPlan):
             )
         return LogicalGetPandasReadSeq(empty, df)
 
-    def _translate_expr(self, expr, source_plan: LazyPlan, name: str | None = None):
+    def _resolve_join_type(self, how: str):
+        assert plan_optimizer is not None
+        join_type = {
+            "inner": plan_optimizer.CJoinType.INNER,
+            "left": plan_optimizer.CJoinType.LEFT,
+            "right": plan_optimizer.CJoinType.RIGHT,
+            "outer": plan_optimizer.CJoinType.OUTER,
+        }.get(how)
+        if join_type is None:
+            raise NotImplementedError(f"Unsupported join type: {how}")
+        return join_type
+
+    def _translate_expr(self, expr, source_plan: LazyPlanLike, name: str | None = None):
         if isinstance(expr, ColumnRef):
             return ColRefExpression(
                 source_plan.empty_data[[expr.name]],
@@ -207,12 +252,17 @@ class DataJAXPlan(LazyPlan):
 
     def _translate_trace(
         self, trace: Sequence[object], empty_data: pd.DataFrame
-    ) -> LazyPlan:
-        plan: LazyPlan | None = None
+    ) -> LazyPlanLike:
+        plan: LazyPlanLike | None = None
         for step in trace:
             if isinstance(step, InputStep):
                 plan = self._translate_input_step(step, empty_data)
-            elif isinstance(step, ProjectStep):
+                continue
+
+            if plan is None:
+                raise ValueError("Trace must start with an InputStep")
+
+            if isinstance(step, ProjectStep):
                 plan = self._translate_project_step(step, plan)
             elif isinstance(step, FilterStep):
                 plan = self._translate_filter_step(step, plan)
@@ -231,7 +281,8 @@ class DataJAXPlan(LazyPlan):
 
     def _translate_input_step(
         self, step: InputStep, empty_data: pd.DataFrame
-    ) -> LazyPlan:
+    ) -> LazyPlanLike:
+        assert bodo is not None
         if bodo.dataframe_library_run_parallel:
             return LogicalGetPandasReadParallel(
                 empty_data,
@@ -241,8 +292,8 @@ class DataJAXPlan(LazyPlan):
         return LogicalGetPandasReadSeq(empty_data, self._input_df)
 
     def _translate_project_step(
-        self, step: ProjectStep, source_plan: LazyPlan
-    ) -> LazyPlan:
+        self, step: ProjectStep, source_plan: LazyPlanLike
+    ) -> LazyPlanLike:
         empty_data = source_plan.empty_data[list(step.columns)]
         exprs = [
             ColRefExpression(
@@ -255,12 +306,14 @@ class DataJAXPlan(LazyPlan):
         return LogicalProjection(empty_data, source_plan, exprs)
 
     def _translate_filter_step(
-        self, step: FilterStep, source_plan: LazyPlan
-    ) -> LazyPlan:
+        self, step: FilterStep, source_plan: LazyPlanLike
+    ) -> LazyPlanLike:
         predicate = self._translate_expr(step.predicate, source_plan)
         return LogicalFilter(source_plan.empty_data, source_plan, predicate)
 
-    def _translate_map_step(self, step: MapStep, source_plan: LazyPlan) -> LazyPlan:
+    def _translate_map_step(
+        self, step: MapStep, source_plan: LazyPlanLike
+    ) -> LazyPlanLike:
         empty_data = source_plan.empty_data.copy()
         existing_cols = list(empty_data.columns)
         exprs = []
@@ -294,8 +347,8 @@ class DataJAXPlan(LazyPlan):
         return LogicalProjection(empty_data[new_cols], source_plan, exprs)
 
     def _translate_aggregate_step(
-        self, step: AggregateStep, source_plan: LazyPlan
-    ) -> LazyPlan:
+        self, step: AggregateStep, source_plan: LazyPlanLike
+    ) -> LazyPlanLike:
         key_dtype = source_plan.empty_data[step.key_alias].dtype
         value_dtype = source_plan.empty_data[step.value_alias].dtype
         result_dtype = self._AGG_RESULT_DTYPES.get(step.agg, value_dtype)
@@ -318,13 +371,11 @@ class DataJAXPlan(LazyPlan):
         return LogicalAggregate(empty_data, source_plan, [key_idx], [agg_expr])
 
     def _translate_join_step(
-        self, step: JoinStep, source_plan: LazyPlan
-    ) -> LazyPlan:
-        join_type = self._JOIN_TYPES.get(step.how)
-        if join_type is None:
-            raise NotImplementedError(f"Unsupported join type: {step.how}")
+        self, step: JoinStep, source_plan: LazyPlanLike
+    ) -> LazyPlanLike:
+        join_type = self._resolve_join_type(step.how)
 
-        right_df = step.right_data
+        right_df = cast("pd.DataFrame", step.right_data)
         right_plan = self._plan_from_pandas(right_df)
 
         # Only attempt to rebalance RHS when running the dataframe library in parallel.
@@ -332,17 +383,26 @@ class DataJAXPlan(LazyPlan):
         # _get_df_python_func_plan triggers a scalar-UDF pathway inside Bodo
         # that expects a Series-like output (leading to dtype errors).
         if self.resources is not None:
+            bodo_module: Any | None = None
             try:
-                import bodo  # local import to avoid sandbox import errors
-                run_parallel = getattr(bodo, "dataframe_library_run_parallel", False)
+                import bodo as bodo_module  # type: ignore[import-not-found]
+
+                run_parallel = bool(
+                    getattr(bodo_module, "dataframe_library_run_parallel", False)
+                )
             except Exception:
                 run_parallel = False
             import os
+
             if os.environ.get("DATAJAX_DISABLE_NATIVE_REBALANCE", "0") == "1":
                 run_parallel = False
 
             if run_parallel:
-                mesh_shape = mesh_shape_from_resource(self.resources, bodo.get_size())
+                assert bodo_module is not None
+                mesh_shape = mesh_shape_from_resource(
+                    self.resources,
+                    cast("Any", bodo_module).get_size(),
+                )
                 axis_idx = getattr(self, "_primary_axis_idx", 0)
                 try:
                     tmp = _get_df_python_func_plan(
@@ -380,13 +440,16 @@ class DataJAXPlan(LazyPlan):
                 except Exception:
                     pass
 
-        left_cols = list(source_plan.empty_data.columns)
-        right_cols = list(right_plan.empty_data.columns)
-        left_key_idx = source_plan.empty_data.columns.get_loc(step.left_on)
-        right_key_idx = right_plan.empty_data.columns.get_loc(step.right_on)
+        left_empty = cast("pd.DataFrame", source_plan.empty_data)
+        right_empty_data = cast("pd.DataFrame", right_plan.empty_data)
+
+        left_cols = list(left_empty.columns)
+        right_cols = list(right_empty_data.columns)
+        left_key_idx = left_empty.columns.get_loc(step.left_on)
+        right_key_idx = right_empty_data.columns.get_loc(step.right_on)
 
         combined = pd.concat(
-            [source_plan.empty_data.iloc[0:0], right_plan.empty_data.iloc[0:0]],
+            [left_empty.iloc[0:0], right_empty_data.iloc[0:0]],
             axis=1,
         )
         combined.columns = [f"{name}__{i}" for i, name in enumerate(combined.columns)]
@@ -399,7 +462,7 @@ class DataJAXPlan(LazyPlan):
             [(left_key_idx, right_key_idx)],
         )
 
-        n_left_indices = get_n_index_arrays(source_plan.empty_data.index)
+        n_left_indices = int(get_n_index_arrays(left_empty.index))
         col_indices = list(range(len(left_cols)))
         for i, col in enumerate(right_cols):
             if col in left_cols:
@@ -408,9 +471,7 @@ class DataJAXPlan(LazyPlan):
 
         output_columns: list[str] = list(left_cols)
         output_columns.extend(col for col in right_cols if col not in left_cols)
-        output_data: dict[str, pd.Series] = {
-            col: source_plan.empty_data[col] for col in left_cols
-        }
+        output_data: dict[str, Any] = {col: left_empty[col] for col in left_cols}
         right_empty = right_df.head(0)
         for col in right_cols:
             if col in output_data:
@@ -426,20 +487,25 @@ class DataJAXPlan(LazyPlan):
         )
 
     def _translate_repartition_step(
-        self, step: RepartitionStep, source_plan: LazyPlan
-    ) -> LazyPlan:
+        self, step: RepartitionStep, source_plan: LazyPlanLike
+    ) -> LazyPlanLike:
         spec = step.spec
         is_key_partition = getattr(spec, "kind", None) == "key"
         has_key = getattr(spec, "key", None) is not None
         if is_key_partition and has_key:
             if self.resources is None:
                 return source_plan
+            bodo_module: Any | None = None
             try:
-                import bodo  # local import to avoid sandbox import errors
-                run_parallel = getattr(bodo, "dataframe_library_run_parallel", False)
+                import bodo as bodo_module  # type: ignore[import-not-found]
+
+                run_parallel = bool(
+                    getattr(bodo_module, "dataframe_library_run_parallel", False)
+                )
             except Exception:
                 run_parallel = False
             import os
+
             if os.environ.get("DATAJAX_DISABLE_NATIVE_REBALANCE", "0") == "1":
                 run_parallel = False
 
@@ -448,12 +514,17 @@ class DataJAXPlan(LazyPlan):
                 # would expect a Series-like return.
                 return source_plan
 
-            mesh_shape = mesh_shape_from_resource(self.resources, bodo.get_size())
+            assert bodo_module is not None
+            mesh_shape = mesh_shape_from_resource(
+                self.resources,
+                cast("Any", bodo_module).get_size(),
+            )
             axis_idx = resolve_mesh_axis(getattr(spec, "axis", None), self.resources, 0)
             try:
+                empty_data = cast("pd.DataFrame", source_plan.empty_data)
                 tmp = _get_df_python_func_plan(
                     source_plan,
-                    source_plan.empty_data,
+                    empty_data,
                     rebalance_by_key,
                     (spec.key, mesh_shape, axis_idx),
                     {},
@@ -468,19 +539,20 @@ class DataJAXPlan(LazyPlan):
                     f"axis={axis_name or axis_idx} shape={mesh_shape}"
                 )
                 self._primary_axis_idx = axis_idx
-                return getattr(tmp, "_plan", tmp)
+                return cast("LazyPlanLike", getattr(tmp, "_plan", tmp))
             except Exception:
                 return source_plan
 
-        indices = list(range(len(source_plan.empty_data.columns)))
-        n_index_cols = get_n_index_arrays(source_plan.empty_data.index)
+        empty_data = cast("pd.DataFrame", source_plan.empty_data)
+        indices = list(range(len(empty_data.columns)))
+        n_index_cols = int(get_n_index_arrays(empty_data.index))
         indices.extend(
             range(
-                len(source_plan.empty_data.columns),
-                len(source_plan.empty_data.columns) + n_index_cols,
+                len(empty_data.columns),
+                len(empty_data.columns) + n_index_cols,
             )
         )
         exprs = make_col_ref_exprs(indices, source_plan)
-        projection = LogicalProjection(source_plan.empty_data, source_plan, exprs)
-        projection.target_sharding = step.spec
+        projection = LogicalProjection(empty_data, source_plan, exprs)
+        cast("Any", projection).target_sharding = step.spec
         return projection

--- a/datajax/runtime/bodo_stub.py
+++ b/datajax/runtime/bodo_stub.py
@@ -16,13 +16,13 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 @overload
-def jit(fn: None = None, *, parallel: bool | None = None, **_: Any) -> Callable[[F], F]:
-    ...
+def jit(
+    fn: None = None, *, parallel: bool | None = None, **_: Any
+) -> Callable[[F], F]: ...
 
 
 @overload
-def jit(fn: F, *, parallel: bool | None = None, **_: Any) -> F:
-    ...
+def jit(fn: F, *, parallel: bool | None = None, **_: Any) -> F: ...
 
 
 def jit(

--- a/datajax/runtime/executor.py
+++ b/datajax/runtime/executor.py
@@ -151,7 +151,15 @@ def execute(plan: ExecutionPlan | DataJAXPlan, *args, **kwargs) -> Any:
     from datajax.runtime.bodo_plan import DataJAXPlan
 
     if isinstance(plan, DataJAXPlan):
-        from bodo.pandas.plan import execute_plan as execute_bodo_plan
+        try:
+            from bodo.pandas.plan import (  # pyright: ignore[reportMissingImports]
+                execute_plan as execute_bodo_plan,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "Bodo is not installed; install the optional dependency group "
+                "'.[bodo]' to execute DataJAXPlan objects."
+            ) from exc
 
         return execute_bodo_plan(plan)
 

--- a/datajax/runtime/executor.py
+++ b/datajax/runtime/executor.py
@@ -1,4 +1,3 @@
-
 """Execution backend management preferring Bodo by default."""
 
 from __future__ import annotations
@@ -31,6 +30,7 @@ class ExecutionBackend(Protocol):
 
     def compile_callable(self, fn: Callable[..., Any]) -> Callable[..., Any]:
         """Return a callable ready for execution on this backend."""
+        ...
 
 
 class PandasBackend:
@@ -155,19 +155,19 @@ def execute(plan: ExecutionPlan | DataJAXPlan, *args, **kwargs) -> Any:
 
         return execute_bodo_plan(plan)
 
-    # For now, we assume that the ExecutionPlan is a single-stage plan
-    # that contains a callable.
-    if len(plan.stages) != 1:
-        raise NotImplementedError("Multi-stage plans are not yet supported")
+    from datajax.runtime.bodo_pipeline import compile_plan_with_backend
 
-    stage = plan.stages[0]
-    if not callable(stage.steps[0]):
-        raise TypeError("Expected a callable step in the execution plan")
+    frame = kwargs.pop("frame", None)
+    if frame is None and args:
+        frame, *args = args
+    if frame is None:
+        raise TypeError("ExecutionPlan execution requires a pandas DataFrame `frame=`")
+    if args or kwargs:
+        raise TypeError("Unexpected extra arguments when executing an ExecutionPlan")
 
-    fn = stage.steps[0]
     backend = get_active_backend()
-    compiled_fn = backend.compile_callable(fn)
-    return compiled_fn(*args, **kwargs)
+    compiled = compile_plan_with_backend(plan, backend)
+    return compiled.run(frame)
 
 
 __all__ = [

--- a/datajax/runtime/mesh.py
+++ b/datajax/runtime/mesh.py
@@ -120,7 +120,13 @@ def compute_destinations_by_key(
 def rebalance_by_key(df, key: str, mesh_shape: Sequence[int], axis_index: int = 0):
     """Rebalance a pandas DataFrame by hashed key for the given mesh layout."""
 
-    from bodo.libs import distributed_api
+    try:
+        from bodo.libs import distributed_api  # pyright: ignore[reportMissingImports]
+    except ImportError as exc:
+        raise RuntimeError(
+            "Bodo is not installed; install the optional dependency group "
+            "'.[bodo]' to use mesh-aware repartitioning."
+        ) from exc
 
     total = 1
     for s in mesh_shape:

--- a/datajax/runtime/mesh.py
+++ b/datajax/runtime/mesh.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -31,7 +31,8 @@ def mesh_shape_from_resource(resources, world_size: int) -> tuple[int, ...]:
             total *= max(size, 1)
         if total != int(world_size):
             raise ValueError(
-                f"Resource axis_sizes={shape} does not multiply to world_size={world_size}"
+                f"Resource axis_sizes={shape} does not multiply to world_size="
+                f"{world_size}"
             )
         return shape
     if not axes or len(axes) == 1:
@@ -109,9 +110,10 @@ def compute_destinations_by_key(
     mesh_shape: Sequence[int],
     axis_index: int,
 ) -> np.ndarray:
-    import pandas as pd
+    import pandas.util as pandas_util
 
-    hashed = pd.util.hash_pandas_object(df[key], index=False).to_numpy(dtype=np.uint64)
+    hash_fn = cast("Any", pandas_util.hash_pandas_object)
+    hashed = np.asarray(hash_fn(df[key], index=False), dtype=np.uint64)
     return compute_destinations_for_mesh(hashed, mesh_shape, axis_index)
 
 

--- a/experiments/debug_dtype.py
+++ b/experiments/debug_dtype.py
@@ -1,44 +1,56 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
-import pandas as pd
 import os
 
-# Set environment variables to match the failing test
-os.environ["DATAJAX_USE_BODO_STUB"] = "0"
-os.environ["DATAJAX_ALLOW_BODO_IMPORT"] = "1"
-os.environ["DATAJAX_NATIVE_BODO"] = "1"
+import pandas as pd
 
-# Import after setting env vars
 from datajax import Frame, djit
+from datajax.runtime import executor as runtime_executor
 
-# Create sample data with explicit dtypes
-sample_frame = pd.DataFrame({
-    "user_id": [1, 2, 1, 3],
-    "unit_price": [10.0, 5.0, 2.0, 4.0],
-    "qty": [2, 3, 5, 1],
-})
 
-print("Original dtypes:")
-print(sample_frame.dtypes)
-print()
+def main() -> int:
+    # Set environment variables to match the failing test.
+    os.environ["DATAJAX_USE_BODO_STUB"] = "0"
+    os.environ["DATAJAX_ALLOW_BODO_IMPORT"] = "1"
+    os.environ["DATAJAX_NATIVE_BODO"] = "1"
+    runtime_executor.reset_backend()
 
-# Test with djit decorator
-@djit
-def featurize(df: Frame) -> Frame:
-    print("Input unit_price dtype:", df.unit_price.dtype)
-    print("Input unit_price values:", df.unit_price.values)
-    revenue = (df.unit_price * df.qty).rename("revenue")
-    print("Revenue dtype:", revenue.dtype)
-    print("Revenue values:", revenue.values)
-    result = revenue.groupby(df.user_id).sum()
-    return result
+    sample_frame = pd.DataFrame(
+        {
+            "user_id": [1, 2, 1, 3],
+            "unit_price": [10.0, 5.0, 2.0, 4.0],
+            "qty": [2, 3, 5, 1],
+        }
+    )
 
-try:
-    result = featurize(sample_frame)
-    print("\nFinal result:")
-    print(result.to_pandas())
-    print("Result dtypes:")
-    print(result.to_pandas().dtypes)
-except Exception as e:
-    print(f"DataJAX failed: {e}")
+    print("Original dtypes:")
+    print(sample_frame.dtypes)
+    print()
 
+    @djit
+    def featurize(df: Frame) -> Frame:
+        print("Input unit_price dtype:", df.unit_price.dtype)
+        print("Input unit_price values:", df.unit_price.values)
+        revenue = (df.unit_price * df.qty).rename("revenue")
+        print("Revenue dtype:", revenue.dtype)
+        print("Revenue values:", revenue.values)
+        return revenue.groupby(df.user_id).sum()
+
+    try:
+        result = featurize(sample_frame)
+        print("\nFinal result:")
+        print(result.to_pandas())
+        print("Result dtypes:")
+        print(result.to_pandas().dtypes)
+    except Exception as exc:
+        print(f"DataJAX failed: {exc}")
+        return 1
+    finally:
+        runtime_executor.reset_backend()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/debug_scaling.py
+++ b/experiments/debug_scaling.py
@@ -1,62 +1,77 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
-import pandas as pd
 import os
 
-# Set environment variables to match the failing test
-os.environ["DATAJAX_USE_BODO_STUB"] = "0"
-os.environ["DATAJAX_ALLOW_BODO_IMPORT"] = "1"
-os.environ["DATAJAX_NATIVE_BODO"] = "1"
+import pandas as pd
 
-# Import after setting env vars
 from datajax import Frame, djit
-from datajax.ir.graph import InputStep, MapStep, AggregateStep, BinaryExpr, ColumnRef
+from datajax.ir.graph import AggregateStep, BinaryExpr, ColumnRef, InputStep, MapStep
+from datajax.runtime import executor as runtime_executor
 from datajax.runtime.bodo_codegen import generate_bodo_callable
 
-# Create sample data
-sample_frame = pd.DataFrame({
-    "user_id": [1, 2, 1, 3],
-    "unit_price": [10.0, 5.0, 2.0, 4.0],
-    "qty": [2, 3, 5, 1],
-})
 
-print("Original data:")
-print(sample_frame)
-print()
+def main() -> int:
+    # Set environment variables to match the failing test.
+    os.environ["DATAJAX_USE_BODO_STUB"] = "0"
+    os.environ["DATAJAX_ALLOW_BODO_IMPORT"] = "1"
+    os.environ["DATAJAX_NATIVE_BODO"] = "1"
+    runtime_executor.reset_backend()
 
-# Test the codegen directly
-input_step = InputStep(("user_id", "unit_price", "qty"))
-map_step = MapStep(
-    output="revenue",
-    expr=BinaryExpr("mul", ColumnRef("unit_price"), ColumnRef("qty"))
-)
-aggregate_step = AggregateStep(key=ColumnRef("user_id"), key_alias="user_id", value=ColumnRef("revenue"), value_alias="revenue", agg="sum")
+    sample_frame = pd.DataFrame(
+        {
+            "user_id": [1, 2, 1, 3],
+            "unit_price": [10.0, 5.0, 2.0, 4.0],
+            "qty": [2, 3, 5, 1],
+        }
+    )
 
-trace = [input_step, map_step, aggregate_step]
+    print("Original data:")
+    print(sample_frame)
+    print()
 
-# Generate the Bodo callable
-fn, source, namespace = generate_bodo_callable(trace)
+    input_step = InputStep(("user_id", "unit_price", "qty"))
+    map_step = MapStep(
+        output="revenue",
+        expr=BinaryExpr("mul", ColumnRef("unit_price"), ColumnRef("qty")),
+    )
+    aggregate_step = AggregateStep(
+        key=ColumnRef("user_id"),
+        key_alias="user_id",
+        value=ColumnRef("revenue"),
+        value_alias="revenue",
+        agg="sum",
+    )
+    trace = [input_step, map_step, aggregate_step]
 
-print("Generated code:")
-print(source)
-print()
+    fn, source, _namespace = generate_bodo_callable(trace)
 
-# Test with pandas directly
-result = fn(sample_frame.copy())
-print("Pandas result:")
-print(result)
-print()
+    print("Generated code:")
+    print(source)
+    print()
 
-# Test with djit decorator
-@djit
-def featurize(df: Frame) -> Frame:
-    revenue = (df.unit_price * df.qty).rename("revenue")
-    return revenue.groupby(df.user_id).sum()
+    result = fn(sample_frame.copy())
+    print("Pandas result:")
+    print(result)
+    print()
 
-try:
-    result = featurize(sample_frame)
-    print("DataJAX result:")
-    print(result.to_pandas())
-except Exception as e:
-    print(f"DataJAX failed: {e}")
+    @djit
+    def featurize(df: Frame) -> Frame:
+        revenue = (df.unit_price * df.qty).rename("revenue")
+        return revenue.groupby(df.user_id).sum()
 
+    try:
+        djit_result = featurize(sample_frame)
+        print("DataJAX result:")
+        print(djit_result.to_pandas())
+    except Exception as exc:
+        print(f"DataJAX failed: {exc}")
+        return 1
+    finally:
+        runtime_executor.reset_backend()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/export_wavespec.py
+++ b/experiments/export_wavespec.py
@@ -4,6 +4,5 @@ from __future__ import annotations
 
 from datajax.cli.export_wavespec import main
 
-
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/experiments/replay_tuner.py
+++ b/experiments/replay_tuner.py
@@ -4,6 +4,5 @@ from __future__ import annotations
 
 from datajax.cli.replay_tuner import main
 
-
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/experiments/test_fix.py
+++ b/experiments/test_fix.py
@@ -1,57 +1,57 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
-import pandas as pd
 import os
 
-# Set environment variables to match the failing test
-os.environ["DATAJAX_USE_BODO_STUB"] = "0"
-os.environ["DATAJAX_ALLOW_BODO_IMPORT"] = "1"
-os.environ["DATAJAX_NATIVE_BODO"] = "1"
+import pandas as pd
 
-# Import after setting env vars
 from datajax import Frame, djit
 from datajax.runtime import executor as runtime_executor
 
-# Create sample data
-sample_frame = pd.DataFrame({
-    "user_id": [1, 2, 1, 3],
-    "unit_price": [10.0, 5.0, 2.0, 4.0],
-    "qty": [2, 3, 5, 1],
-})
 
-print("Backend:", runtime_executor.active_backend_name())
-print("Backend mode:", runtime_executor.get_active_backend().mode)
+def main() -> int:
+    os.environ["DATAJAX_USE_BODO_STUB"] = "0"
+    os.environ["DATAJAX_ALLOW_BODO_IMPORT"] = "1"
+    os.environ["DATAJAX_NATIVE_BODO"] = "1"
+    runtime_executor.reset_backend()
 
-# Test potential fix - detect if we're in Bodo and compensate
-@djit
-def featurize_fixed(df: Frame) -> Frame:
-    # Check if we're in Bodo backend and compensate for 10x scaling
-    backend = runtime_executor.get_active_backend()
-    unit_price = df.unit_price
+    sample_frame = pd.DataFrame(
+        {
+            "user_id": [1, 2, 1, 3],
+            "unit_price": [10.0, 5.0, 2.0, 4.0],
+            "qty": [2, 3, 5, 1],
+        }
+    )
 
-    if backend.name == "bodo" and backend.mode in {"real", "stub"}:
-        # Compensate for the 10x scaling bug in Bodo
-        unit_price = unit_price / 10.0
+    print("Backend:", runtime_executor.active_backend_name())
+    print("Backend mode:", runtime_executor.get_active_backend().mode)
 
-    revenue = (unit_price * df.qty).rename("revenue")
-    return revenue.groupby(df.user_id).sum()
+    @djit
+    def featurize_fixed(df: Frame) -> Frame:
+        backend = runtime_executor.get_active_backend()
+        unit_price = df.unit_price
 
-result = featurize_fixed(sample_frame)
-print("\nFixed result:")
-print(result.to_pandas().sort_values("user_id").reset_index(drop=True))
+        if backend.name == "bodo" and backend.mode in {"real", "stub"}:
+            unit_price = unit_price / 10.0
 
-# Expected result
-expected = pd.DataFrame({
-    "user_id": [1, 2, 3],
-    "revenue": [30.0, 15.0, 4.0]
-})
-print("\nExpected:")
-print(expected)
+        revenue = (unit_price * df.qty).rename("revenue")
+        return revenue.groupby(df.user_id).sum()
 
-# Verify they match
-pd.testing.assert_frame_equal(
-    result.to_pandas().sort_values("user_id").reset_index(drop=True),
-    expected
-)
-print("\n✅ Fix works!")
+    result = featurize_fixed(sample_frame)
+    print("\nFixed result:")
+    print(result.to_pandas().sort_values("user_id").reset_index(drop=True))
 
+    expected = pd.DataFrame({"user_id": [1, 2, 3], "revenue": [30.0, 15.0, 4.0]})
+    print("\nExpected:")
+    print(expected)
+
+    pd.testing.assert_frame_equal(
+        result.to_pandas().sort_values("user_id").reset_index(drop=True),
+        expected,
+    )
+    print("\nFix works!")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ line-ending = "lf"
 [tool.pyright]
 include = ["datajax"]
 typeCheckingMode = "standard"
+venvPath = "."
+venv = ".venv"
 reportMissingTypeStubs = "warning"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "numpy>=1.24",
   "pandas>=2.0",
   "pyarrow>=12.0",
-  "bodo>=2024.1.0",
 ]
 
 [project.urls]
@@ -42,9 +41,15 @@ dev = [
   "pytest>=8.0",
   "pytest-mock>=3.10",
   "pytest-cov>=4.0",
+  "pip-audit>=2.9",
+  "pre-commit>=3.7",
+  "pandas-stubs>=2.0.0",
   "ruff>=0.4",
   "pyright>=1.1",
   "mypy>=1.8",
+]
+bodo = [
+  "bodo>=2024.1.0",
 ]
 tpu = [
   "jax>=0.4.33",
@@ -60,8 +65,13 @@ path = ["datajax"]
 [tool.ruff]
 line-length = 88
 src = ["datajax", "tests"]
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "Q", "TCH"]
 ignore = ["E203"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["datajax"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/experiments/test_cli_smoke.py
+++ b/tests/experiments/test_cli_smoke.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+
 from datajax.frame.frame import Frame
 from datajax.ir.serialize import trace_to_list
 

--- a/tests/frame/test_frame_ops.py
+++ b/tests/frame/test_frame_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+
 from datajax.api.sharding import shard
 from datajax.frame.frame import Frame
 from datajax.ir.graph import (

--- a/tests/io/test_exporter.py
+++ b/tests/io/test_exporter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+
 from datajax.io.exporter import (
     build_prefix_cohorts,
     coalesce_kv_extents,

--- a/tests/ir/test_serialize.py
+++ b/tests/ir/test_serialize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+
 from datajax.api.sharding import shard
 from datajax.ir.graph import (
     BinaryExpr,

--- a/tests/jax_bridge/test_tpu_adapter.py
+++ b/tests/jax_bridge/test_tpu_adapter.py
@@ -14,7 +14,6 @@ from datajax.jax_bridge.tpu_adapter import (
 )
 
 jax = pytest.importorskip("jax")
-from jax.sharding import PartitionSpec  # noqa: E402
 
 
 @djit

--- a/tests/planner/test_metrics_extensions.py
+++ b/tests/planner/test_metrics_extensions.py
@@ -108,7 +108,7 @@ def test_merge_runtime_counters_overrides_fields(sample_frame):
         "shuffle_bytes": 5678,
         "wgmma_occupancy": 0.9,
         "l2_reuse": 0.5,
-        "notes": ["runtime"]
+        "notes": ["runtime"],
     }
     merge_runtime_counters(metrics, counters)
     assert metrics.runtime_input_bytes == 1234

--- a/tests/planner/test_optimizer.py
+++ b/tests/planner/test_optimizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from datajax.api.sharding import Resource, shard
 from datajax.ir.graph import (
     BinaryExpr,

--- a/tests/runtime/test_bodo_plan.py
+++ b/tests/runtime/test_bodo_plan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+
 from datajax.frame.frame import Frame
 from datajax.runtime.bodo_plan import DataJAXPlan
 

--- a/tests/runtime/test_mesh_plan.py
+++ b/tests/runtime/test_mesh_plan.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import pytest
+
 from datajax.api.sharding import Resource, shard
 from datajax.runtime.mesh import compute_destinations_for_mesh, mesh_shape_from_resource
 
@@ -26,6 +28,7 @@ def test_destination_mapping_two_axes_primary_first(monkeypatch: Any) -> None:
     def fake_rebalance(df, dests=None, **kwargs):
         captured["dests"] = np.asarray(dests)
         return df
+
     monkeypatch.setattr(
         "bodo.libs.distributed_api.rebalance",
         fake_rebalance,
@@ -52,6 +55,7 @@ def test_destination_mapping_two_axes_primary_second(monkeypatch: Any) -> None:
     def fake_rebalance(df, dests=None, **kwargs):
         captured["dests"] = np.asarray(dests)
         return df
+
     monkeypatch.setattr(
         "bodo.libs.distributed_api.rebalance",
         fake_rebalance,
@@ -85,7 +89,9 @@ def _collect_lazy_nodes(plan):
 
 
 def test_join_inserts_rhs_rebalance_with_mesh(sample_frame):
+    pytest.importorskip("bodo.pandas.plan")
     import bodo
+
     from datajax.frame.frame import Frame
     from datajax.runtime.bodo_plan import DataJAXPlan
 


### PR DESCRIPTION
Summary
- Fix AggregateStep codegen to respect agg + compute key/value expressions
- Execute multi-stage ExecutionPlans correctly
- Add plan introspection helpers (ExecutionPlan.explain()/to_dict(), djit/pjit explain helpers)
- Add Makefile Interface Contract targets, pre-commit hooks, and CI workflow

Why
- Correctness: avoid silently wrong aggregations and broken execution paths
- Developer experience: make it easy to inspect plans and generated replay code

How to test
- make setup
- make all

Notes
- deps-audit is advisory in baseline (AGENT_MODE=baseline); CI still runs it.