### PR TITLE
feat: harden join semantics and distribution contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ This definition can be handed to a TPU registry (for example,
 actual hardware.
 
 The bridge currently supports filter/project traces, `groupby` reductions (`sum`, `count`, `mean`,
-`min`, `max`), and inner hash joins while capturing sharding metadata (mesh, partition specs).
+`min`, `max`), and join lowering with pandas-parity semantics (`inner`, `left`, `right`, `outer`,
+including suffix handling) while capturing sharding metadata (mesh, partition specs).
 Follow-up work will add ragged prefill metadata so the lowered plan can exercise TPU-optimised
 kernels such as Ragged Paged Attention v3.
 

--- a/datajax/ir/graph.py
+++ b/datajax/ir/graph.py
@@ -85,6 +85,7 @@ class JoinStep:
     how: str
     right_columns: tuple[str, ...]
     right_data: Any
+    suffixes: tuple[str, str] = ("_x", "_y")
 
 
 @dataclass(frozen=True)

--- a/datajax/ir/serialize.py
+++ b/datajax/ir/serialize.py
@@ -126,6 +126,7 @@ def step_to_dict(step: object) -> dict[str, Any]:
             "right_on": step.right_on,
             "how": step.how,
             "right_columns": list(step.right_columns),
+            "suffixes": list(step.suffixes),
             # Optional binding; caller may add a tag name to look up tables
             "rhs_tag": None,
         }
@@ -166,12 +167,17 @@ def step_from_dict(
         right_df = None
         if rhs_tables is not None and rhs_tag is not None:
             right_df = rhs_tables.get(str(rhs_tag))
+        raw_suffixes = data.get("suffixes", ("_x", "_y"))
+        suffixes = tuple(str(item) for item in raw_suffixes)  # type: ignore[arg-type]
+        if len(suffixes) != 2:
+            suffixes = ("_x", "_y")
         return JoinStep(
             left_on=str(data["left_on"]),
             right_on=str(data["right_on"]),
             how=str(data.get("how", "inner")),
             right_columns=tuple(data.get("right_columns", ())),
             right_data=right_df,
+            suffixes=(suffixes[0], suffixes[1]),
         )
     if t == "repartition":
         spec = data.get("spec", {})

--- a/datajax/runtime/bodo_codegen.py
+++ b/datajax/runtime/bodo_codegen.py
@@ -124,7 +124,8 @@ def generate_bodo_callable(
             constants[const_name] = step.right_data
             lines.append(
                 f"    frame = frame.merge({const_name}, left_on={step.left_on!r}, "
-                f"right_on={step.right_on!r}, how={step.how!r})"
+                f"right_on={step.right_on!r}, how={step.how!r}, "
+                f"suffixes={step.suffixes!r})"
             )
         else:
             raise TypeError(f"Unsupported IR step for Bodo codegen: {step!r}")

--- a/tests/ir/test_serialize.py
+++ b/tests/ir/test_serialize.py
@@ -32,6 +32,7 @@ def _build_trace():
             how="left",
             right_columns=tuple(rhs.columns),
             right_data=rhs,
+            suffixes=("_left", "_right"),
         ),
         RepartitionStep(spec=shard.by_key("user_id")),
     ]
@@ -58,6 +59,7 @@ def test_trace_roundtrip_including_join_rhs():
     assert isinstance(restored[0], InputStep)
     join_step = next(step for step in restored if isinstance(step, JoinStep))
     assert join_step.right_data is rhs
+    assert join_step.suffixes == ("_left", "_right")
 
 
 def test_trace_roundtrip_keeps_repartition_spec():

--- a/tests/jax_bridge/test_lowering.py
+++ b/tests/jax_bridge/test_lowering.py
@@ -31,6 +31,19 @@ COUNTRY_DIM_DUP = pd.DataFrame(
         "country_code": [1, 99, 2],
     }
 )
+COUNTRY_DIM_WITH_VALUE = pd.DataFrame(
+    {
+        "country_id": [100, 200],
+        "value": [1000, 2000],
+        "country_code": [1, 2],
+    }
+)
+COUNTRY_DIM_OUTER = pd.DataFrame(
+    {
+        "country_id": [100, 999],
+        "country_code": [1, 9],
+    }
+)
 
 
 @djit
@@ -41,6 +54,31 @@ def join_country(frame):
 @djit
 def join_country_duplicates(frame):
     return frame.join(COUNTRY_DIM_DUP, on="country_id")
+
+
+@djit
+def join_country_left(frame):
+    return frame.join(COUNTRY_DIM_OUTER, on="country_id", how="left")
+
+
+@djit
+def join_country_right(frame):
+    return frame.join(COUNTRY_DIM_OUTER, on="country_id", how="right")
+
+
+@djit
+def join_country_outer(frame):
+    return frame.join(COUNTRY_DIM_OUTER, on="country_id", how="outer")
+
+
+@djit
+def join_country_suffixes(frame):
+    return frame.join(
+        COUNTRY_DIM_WITH_VALUE,
+        on="country_id",
+        how="inner",
+        suffixes=("_l", "_r"),
+    )
 
 
 def test_lower_to_jax_emits_callable():
@@ -137,4 +175,52 @@ def test_lower_to_jax_handles_join_one_to_many():
     output = lowered.callable(arrays)
     out_df = pd.DataFrame({name: np.asarray(arr) for name, arr in output.items()})
     out_df = out_df.sort_values(["user_id", "country_code"]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(out_df, result, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    ("fn", "sort_cols"),
+    [
+        (join_country_left, ["user_id", "country_id", "country_code"]),
+        (join_country_right, ["country_id", "country_code"]),
+        (join_country_outer, ["country_id", "country_code"]),
+    ],
+)
+def test_lower_to_jax_handles_non_inner_joins(fn, sort_cols):
+    wrapped = pjit(
+        fn,
+        out_shardings=shard.by_key("country_id"),
+        resources=Resource(mesh_axes=("rows",), world_size=1),
+    )
+    df = pd.DataFrame(
+        {"user_id": [1, 2, 3], "country_id": [100, 200, 300], "value": [10, 20, 30]}
+    )
+    result = wrapped(df).to_pandas().sort_values(sort_cols).reset_index(drop=True)
+
+    lowered = wrapped.lower_to_jax(df)
+    arrays = dataframe_to_device_arrays(df)
+    output = lowered.callable(arrays)
+    out_df = pd.DataFrame({name: np.asarray(arr) for name, arr in output.items()})
+    out_df = out_df.sort_values(sort_cols).reset_index(drop=True)
+    pd.testing.assert_frame_equal(out_df, result, check_dtype=False)
+
+
+def test_lower_to_jax_handles_join_suffixes():
+    fn = pjit(
+        join_country_suffixes,
+        out_shardings=shard.by_key("country_id"),
+        resources=Resource(mesh_axes=("rows",), world_size=1),
+    )
+    df = pd.DataFrame(
+        {"user_id": [1, 2, 3], "country_id": [100, 200, 100], "value": [10, 20, 30]}
+    )
+    result = (
+        fn(df).to_pandas().sort_values(["user_id", "value_l"]).reset_index(drop=True)
+    )
+
+    lowered = fn.lower_to_jax(df)
+    arrays = dataframe_to_device_arrays(df)
+    output = lowered.callable(arrays)
+    out_df = pd.DataFrame({name: np.asarray(arr) for name, arr in output.items()})
+    out_df = out_df.sort_values(["user_id", "value_l"]).reset_index(drop=True)
     pd.testing.assert_frame_equal(out_df, result, check_dtype=False)


### PR DESCRIPTION
## Summary
- add join suffix metadata to IR and serialization
- enforce conservative post-join sharding contracts for stable distribution semantics
- make join schema planning suffix-aware for overlapping columns
- align execution lowerings (codegen/native/JAX) with join suffix semantics
- add JAX fallback path for `left`/`right`/`outer` joins using pandas-parity merge
- add regression tests across frame/api/planner/IR/JAX paths

## Why
Join behavior had parity gaps for overlapping column names and inconsistent sharding propagation after joins. This PR makes those contracts explicit and stable while preserving current execution paths.

## Validation
- `make check`
- `make all`
