### PR TITLE
feat: relational parity suite + join/distribution contract hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade pip uv
 
-      - name: Run gates
+      - name: Run interface gates (includes parity)
         env:
           AGENT_MODE: baseline
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup bootstrap check format lint type test deps-audit all fix clean
+.PHONY: setup bootstrap check format lint type test parity deps-audit all fix clean
 
 AGENT_MODE ?= baseline
 VENV ?= .venv
@@ -31,6 +31,9 @@ fix:
 test:
 	$(VENV)/bin/pytest -q
 
+parity:
+	$(VENV)/bin/pytest -q tests/parity/test_relational_parity.py
+
 deps-audit:
 	@if [ "$(AGENT_MODE)" = "production" ]; then \
 		$(VENV)/bin/pip-audit --progress-spinner off . ; \
@@ -41,6 +44,7 @@ deps-audit:
 all:
 	$(MAKE) check
 	$(MAKE) test
+	$(MAKE) parity
 	$(MAKE) deps-audit
 
 clean:

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ This definition can be handed to a TPU registry (for example,
 actual hardware.
 
 The bridge currently supports filter/project traces, `groupby` reductions (`sum`, `count`, `mean`,
-`min`, `max`), and join lowering with pandas-parity semantics (`inner`, `left`, `right`, `outer`,
-including suffix handling) while capturing sharding metadata (mesh, partition specs).
+`min`, `max`), and join lowering with pandas-parity semantics (`inner`, `left`, `right`, `outer`;
+`on` and `left_on`/`right_on`; multi-key joins; suffix-collision validation) while capturing
+sharding metadata (mesh, partition specs).
 Follow-up work will add ragged prefill metadata so the lowered plan can exercise TPU-optimised
 kernels such as Ragged Paged Attention v3.
 
@@ -192,21 +193,13 @@ The `@djit` decorator traces operations on the `Frame` wrapper. `pjit` attaches 
     - A comprehensive test suite covers tracing, planning, and backend execution.
     - A benchmark (`benchmarks/feature_pipeline.py`) compares pandas, the Bodo stub, and native Bodo execution.
 
-## Next Steps
+## Roadmap
 
-Our immediate focus is on hardening the prototype and moving towards a polished "JAX for data" experience.
-
-- **Core Planner & Execution**:
-    - Improve Bodo-native lowering to remove Python UDFs and add a native repartition operator.
-    - Enforce `Resource` meshes for multi-axis data layouts.
-    - Implement a planner optimiser for fusion, pushdowns, and cost-based choices.
-- **Feature Coverage**:
-    - Add IR nodes and lowering rules for window functions, multi-aggregation pipelines, and advanced join strategies.
-    - Improve I/O for Arrow/Parquet with sharding hints.
-- **Developer Experience**:
-    - Tighten JAX interoperability and data interchange (DLPack).
-    - Improve plan introspection, profiling, and error reporting.
-    - Expand CI to cover MPI environments and performance regressions.
+- Extend relational parity coverage across wider join/groupby/filter compositions.
+- Add native repartition operators to the Bodo `LazyPlan` path.
+- Tighten multi-axis mesh planning and validation for distributed layouts.
+- Expand optimizer rules for pushdown/fusion decisions with cost hints.
+- Add performance regression gates for representative tabular workloads.
 
 For more detail, see the contributor guidelines (`AGENTS.md`), the development plan (`docs/development_plan.md`), the native Bodo plan details (`docs/native_plan.md`), and the offline intelligence guide (`docs/offline_intelligence.md`).
 

--- a/datajax/ir/graph.py
+++ b/datajax/ir/graph.py
@@ -80,8 +80,8 @@ class ProjectStep:
 
 @dataclass(frozen=True)
 class JoinStep:
-    left_on: str
-    right_on: str
+    left_on: tuple[str, ...]
+    right_on: tuple[str, ...]
     how: str
     right_columns: tuple[str, ...]
     right_data: Any

--- a/datajax/ir/join_semantics.py
+++ b/datajax/ir/join_semantics.py
@@ -1,0 +1,158 @@
+"""Join key and output-schema semantics shared across runtimes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+JoinKeys = tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class JoinColumnPlan:
+    left_pairs: tuple[tuple[str, str], ...]
+    right_pairs: tuple[tuple[int, str, str], ...]
+    output_columns: tuple[str, ...]
+    overlap_columns: tuple[str, ...]
+    dropped_right_keys: tuple[str, ...]
+
+
+def _normalize_keys(
+    value: str | Sequence[str] | None,
+    *,
+    label: str,
+) -> JoinKeys:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        keys = (value,)
+    else:
+        keys = tuple(str(key) for key in value)
+    if not keys:
+        raise ValueError(f"`{label}` must contain at least one column")
+    if any(not key for key in keys):
+        raise ValueError(f"`{label}` cannot contain empty column names")
+    if len(set(keys)) != len(keys):
+        raise ValueError(f"`{label}` cannot contain duplicate columns: {keys!r}")
+    return keys
+
+
+def normalize_join_keys(
+    *,
+    on: str | Sequence[str] | None,
+    left_on: str | Sequence[str] | None,
+    right_on: str | Sequence[str] | None,
+) -> tuple[JoinKeys, JoinKeys]:
+    on_keys = _normalize_keys(on, label="on")
+    if on_keys:
+        if left_on is not None or right_on is not None:
+            raise ValueError("Use either `on` or (`left_on`, `right_on`), not both")
+        return on_keys, on_keys
+
+    left_keys = _normalize_keys(left_on, label="left_on")
+    right_keys = _normalize_keys(right_on, label="right_on")
+    if not left_keys and not right_keys:
+        raise ValueError("join requires `on` or both `left_on` and `right_on`")
+    if not left_keys or not right_keys:
+        raise ValueError("join requires both `left_on` and `right_on` together")
+    if len(left_keys) != len(right_keys):
+        raise ValueError(
+            "`left_on` and `right_on` must reference the same number of columns"
+        )
+    return left_keys, right_keys
+
+
+def normalize_suffixes(suffixes: tuple[str, str]) -> tuple[str, str]:
+    if len(suffixes) != 2:
+        raise ValueError("suffixes must be a 2-tuple")
+    left_suffix, right_suffix = suffixes
+    if not isinstance(left_suffix, str) or not isinstance(right_suffix, str):
+        raise TypeError("suffixes entries must be strings")
+    return left_suffix, right_suffix
+
+
+def pandas_join_key_arg(keys: JoinKeys) -> str | list[str]:
+    if len(keys) == 1:
+        return keys[0]
+    return list(keys)
+
+
+def build_join_column_plan(
+    *,
+    left_columns: Sequence[str],
+    right_columns: Sequence[str],
+    left_on: JoinKeys,
+    right_on: JoinKeys,
+    suffixes: tuple[str, str],
+) -> JoinColumnPlan:
+    left_cols = tuple(left_columns)
+    right_cols = tuple(right_columns)
+
+    missing_left = [key for key in left_on if key not in left_cols]
+    if missing_left:
+        raise KeyError(f"Left join key columns missing: {missing_left}")
+    missing_right = [key for key in right_on if key not in right_cols]
+    if missing_right:
+        raise KeyError(f"Right join key columns missing: {missing_right}")
+
+    left_suffix, right_suffix = normalize_suffixes(suffixes)
+    dropped_right_keys = tuple(
+        right_key
+        for left_key, right_key in zip(left_on, right_on, strict=True)
+        if left_key == right_key
+    )
+    dropped_right_lookup = set(dropped_right_keys)
+
+    overlap = tuple(
+        col
+        for col in right_cols
+        if col in left_cols and col not in dropped_right_lookup
+    )
+    overlap_lookup = set(overlap)
+
+    left_pairs = tuple(
+        (col, f"{col}{left_suffix}" if col in overlap_lookup else col)
+        for col in left_cols
+    )
+
+    right_pairs_list: list[tuple[int, str, str]] = []
+    for index, col in enumerate(right_cols):
+        if col in dropped_right_lookup:
+            continue
+        out_name = f"{col}{right_suffix}" if col in overlap_lookup else col
+        right_pairs_list.append((index, col, out_name))
+    right_pairs = tuple(right_pairs_list)
+
+    output_columns = tuple(out_name for _, out_name in left_pairs) + tuple(
+        out_name for _, _, out_name in right_pairs
+    )
+    counts = Counter(output_columns)
+    duplicates = tuple(name for name, count in counts.items() if count > 1)
+    if duplicates:
+        raise ValueError(
+            "Join output columns collide after suffix application: "
+            f"{duplicates!r}. Adjust suffixes or input column names."
+        )
+
+    return JoinColumnPlan(
+        left_pairs=left_pairs,
+        right_pairs=right_pairs,
+        output_columns=output_columns,
+        overlap_columns=overlap,
+        dropped_right_keys=dropped_right_keys,
+    )
+
+
+__all__ = [
+    "JoinColumnPlan",
+    "JoinKeys",
+    "build_join_column_plan",
+    "normalize_join_keys",
+    "normalize_suffixes",
+    "pandas_join_key_arg",
+]

--- a/datajax/planner/metrics.py
+++ b/datajax/planner/metrics.py
@@ -125,8 +125,8 @@ def _collect_column_usage(trace: Sequence[object]) -> dict[str, int]:
             cols.add(step.key_alias)
             cols.add(step.value_alias)
         elif isinstance(step, JoinStep):
-            cols.add(step.left_on)
-            cols.add(step.right_on)
+            cols.update(step.left_on)
+            cols.update(step.right_on)
             cols |= set(step.right_columns)
         for c in cols:
             usage[c] = usage.get(c, 0) + 1

--- a/datajax/runtime/bodo_codegen.py
+++ b/datajax/runtime/bodo_codegen.py
@@ -21,6 +21,7 @@ from datajax.ir.graph import (
     ProjectStep,
     RenameExpr,
 )
+from datajax.ir.join_semantics import pandas_join_key_arg
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -122,9 +123,11 @@ def generate_bodo_callable(
             const_name = f"_datajax_join_rhs_{join_index}"
             join_index += 1
             constants[const_name] = step.right_data
+            left_on = pandas_join_key_arg(step.left_on)
+            right_on = pandas_join_key_arg(step.right_on)
             lines.append(
-                f"    frame = frame.merge({const_name}, left_on={step.left_on!r}, "
-                f"right_on={step.right_on!r}, how={step.how!r}, "
+                f"    frame = frame.merge({const_name}, left_on={left_on!r}, "
+                f"right_on={right_on!r}, how={step.how!r}, "
                 f"suffixes={step.suffixes!r})"
             )
         else:

--- a/datajax/runtime/bodo_pipeline.py
+++ b/datajax/runtime/bodo_pipeline.py
@@ -84,6 +84,7 @@ def compile_plan_with_backend(plan: ExecutionPlan, backend) -> CompiledPlan:
             input_schema=input_schema,
             output_schema=plan.final_schema,
             target_sharding=plan.final_sharding,
+            output_sharding=plan.final_sharding,
         )
         compiled_stages.append(
             CompiledStage(stage=fallback_stage, fn=compiled_fn, source=source)

--- a/tests/ir/test_serialize.py
+++ b/tests/ir/test_serialize.py
@@ -27,8 +27,8 @@ def _build_trace():
         InputStep(("user_id", "qty")),
         MapStep(output="qty_scaled", expr=expr),
         JoinStep(
-            left_on="user_id",
-            right_on="user_id",
+            left_on=("user_id",),
+            right_on=("user_id",),
             how="left",
             right_columns=tuple(rhs.columns),
             right_data=rhs,
@@ -59,6 +59,8 @@ def test_trace_roundtrip_including_join_rhs():
     assert isinstance(restored[0], InputStep)
     join_step = next(step for step in restored if isinstance(step, JoinStep))
     assert join_step.right_data is rhs
+    assert join_step.left_on == ("user_id",)
+    assert join_step.right_on == ("user_id",)
     assert join_step.suffixes == ("_left", "_right")
 
 

--- a/tests/parity/test_relational_parity.py
+++ b/tests/parity/test_relational_parity.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from datajax import Frame, djit
+from datajax.runtime import executor as runtime_executor
+
+
+def _sort_for_compare(frame: pd.DataFrame, by: list[str]) -> pd.DataFrame:
+    return frame.sort_values(by, na_position="last").reset_index(drop=True)
+
+
+def _reset_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime_executor.reset_backend()
+    monkeypatch.delenv("DATAJAX_EXECUTOR", raising=False)
+    monkeypatch.delenv("DATAJAX_NATIVE_BODO", raising=False)
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
+def test_join_parity_matches_pandas_for_all_join_modes(
+    how: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_runtime(monkeypatch)
+
+    left = pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 3],
+            "qty": [1, 2, 3, 4],
+            "value": [10, 20, 30, 40],
+        }
+    )
+    right = pd.DataFrame(
+        {
+            "user_id": [1, 2, 2, 5],
+            "value": [100, 200, 250, 500],
+            "country_code": [11, 22, 23, 55],
+        }
+    )
+
+    @djit
+    def pipeline(frame: Frame) -> Frame:
+        return frame.join(right, on="user_id", how=how, suffixes=("_l", "_r"))
+
+    actual = pipeline(left).to_pandas()
+    expected = left.merge(right, on="user_id", how=how, suffixes=("_l", "_r"))
+
+    pd.testing.assert_frame_equal(
+        _sort_for_compare(actual, ["user_id", "country_code"]),
+        _sort_for_compare(expected, ["user_id", "country_code"]),
+        check_dtype=False,
+    )
+
+    record = pipeline.last_execution
+    assert record is not None
+    if hasattr(record.plan, "final_schema"):
+        assert record.plan.final_schema == tuple(expected.columns)
+
+
+def test_multikey_join_parity_matches_pandas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_runtime(monkeypatch)
+
+    left = pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 3],
+            "region": [1, 2, 1, 1],
+            "qty": [1, 2, 3, 4],
+            "value": [10, 20, 30, 40],
+        }
+    )
+    right = pd.DataFrame(
+        {
+            "uid": [1, 2, 2, 4],
+            "region": [1, 1, 2, 1],
+            "value": [100, 200, 250, 400],
+            "segment": [9, 8, 7, 6],
+        }
+    )
+
+    @djit
+    def pipeline(frame: Frame) -> Frame:
+        return frame.join(
+            right,
+            left_on=["user_id", "region"],
+            right_on=["uid", "region"],
+            how="outer",
+            suffixes=("_l", "_r"),
+        )
+
+    actual = pipeline(left).to_pandas()
+    expected = left.merge(
+        right,
+        left_on=["user_id", "region"],
+        right_on=["uid", "region"],
+        how="outer",
+        suffixes=("_l", "_r"),
+    )
+
+    pd.testing.assert_frame_equal(
+        _sort_for_compare(actual, ["region", "user_id", "uid"]),
+        _sort_for_compare(expected, ["region", "user_id", "uid"]),
+        check_dtype=False,
+    )
+
+    record = pipeline.last_execution
+    assert record is not None
+    if hasattr(record.plan, "final_schema"):
+        assert record.plan.final_schema == tuple(expected.columns)
+
+
+def test_relational_filter_and_aggregate_parity(
+    sample_frame: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_runtime(monkeypatch)
+
+    @djit
+    def pipeline(frame: Frame) -> Frame:
+        filtered = frame.filter(frame.qty > 1)
+        total = (filtered.unit_price * filtered.qty).rename("revenue")
+        return total.groupby(filtered.user_id).sum()
+
+    actual = pipeline(sample_frame).to_pandas()
+    expected_filtered = sample_frame[sample_frame["qty"] > 1]
+    expected = (
+        (expected_filtered["unit_price"] * expected_filtered["qty"])
+        .rename("revenue")
+        .groupby(expected_filtered["user_id"])
+        .sum()
+        .reset_index(name="revenue")
+    )
+
+    pd.testing.assert_frame_equal(
+        _sort_for_compare(actual, ["user_id"]),
+        _sort_for_compare(expected, ["user_id"]),
+    )
+
+
+def test_join_suffix_collision_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_runtime(monkeypatch)
+    left = pd.DataFrame({"id": [1], "value": [10], "value_right": [11]})
+    right = pd.DataFrame({"id": [1], "value": [20]})
+
+    @djit
+    def pipeline(frame: Frame) -> Frame:
+        return frame.join(right, on="id", suffixes=("_right", "_right"))
+
+    with pytest.raises(ValueError, match="collide"):
+        _ = pipeline(left)


### PR DESCRIPTION
## Summary
- extend `Frame.join` to support `on`, `left_on`/`right_on`, and multi-key joins with suffix-collision validation
- centralize join schema semantics in `datajax/ir/join_semantics.py` and propagate through planner/runtime serialization/codegen
- add stage-level sharding contract assertions (`target_sharding` -> `output_sharding`) during plan build
- replace JAX non-inner join fallback with native index-based lowering for `left`/`right`/`outer`
- add relational parity tests and enforce parity gate via `make parity` in CI (`make all`)
- refresh README roadmap and bridge capability notes

## Validation
- `make check`
- `make all` (includes parity gate)

## Notes
- baseline-mode `deps-audit` remains advisory; local `pip-audit` SIGABRT behavior is unchanged
